### PR TITLE
webpack 5: Failed to parse source map from...

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
 		"dist/",
 		"ios/",
 		"android/",
-		"JaybabuCapacitorFirebaseAuth.podspec"
+		"JaybabuCapacitorFirebaseAuth.podspec",
+		"src"
 	],
 	"keywords": [
 		"capacitor",


### PR DESCRIPTION
Should fix:
![image](https://user-images.githubusercontent.com/4024049/165001714-12d8a50e-dce5-4991-a167-ddcc29cd4983.png)

webpack 5: Failed to parse source map from ...
Modeled after: https://github.com/mswjs/msw/issues/1030
https://github.com/mswjs/interceptors/pull/204